### PR TITLE
language-lambek

### DIFF
--- a/code/language-lambek/default.nix
+++ b/code/language-lambek/default.nix
@@ -1,0 +1,9 @@
+{ lib, mkDerivation, base } :
+
+mkDerivation {
+    pname = "language-lambek";
+    version = "0";
+    src = ./.;
+    libraryHaskellDepends = [ base ];
+    license = lib.licenses.bsd3;
+}

--- a/code/language-lambek/language-lambek.cabal
+++ b/code/language-lambek/language-lambek.cabal
@@ -1,0 +1,33 @@
+cabal-version: 3.4
+
+name: language-lambek
+version: 0
+
+build-type: Simple
+
+library
+  exposed-modules:
+    Language.Lambek
+    Language.Lambek.Parse
+  hs-source-dirs: src
+  build-depends:
+    , base ^>= 4.20
+    , containers
+    , parsec
+    , text
+    , transformers
+  default-language: Haskell2010
+  default-extensions:
+    GADTs
+    ImportQualifiedPost
+    InstanceSigs
+    MultiParamTypeClasses
+    NamedFieldPuns
+    NoImplicitPrelude
+    NoStarIsType
+    RankNTypes
+    ScopedTypeVariables
+    TupleSections
+    TypeApplications
+    TypeFamilies
+    TypeOperators

--- a/code/language-lambek/language-lambek.cabal
+++ b/code/language-lambek/language-lambek.cabal
@@ -8,6 +8,8 @@ build-type: Simple
 library
   exposed-modules:
     Language.Lambek
+    Language.Lambek.Defn
+    Language.Lambek.Ident
     Language.Lambek.Parse
   hs-source-dirs: src
   build-depends:

--- a/code/language-lambek/src/Language/Lambek.hs
+++ b/code/language-lambek/src/Language/Lambek.hs
@@ -1,0 +1,1 @@
+module Language.Lambek where

--- a/code/language-lambek/src/Language/Lambek/Defn.hs
+++ b/code/language-lambek/src/Language/Lambek/Defn.hs
@@ -1,0 +1,24 @@
+module Language.Lambek.Defn where
+
+import Language.Lambek.Ident
+
+data Defn
+  = Data Ident [Pat] [ConsDecl]
+  | Fun
+  | Class Ident [Pat] [Defn]
+  | Instance Ident [Pat] [Defn]
+
+data ConsDecl
+  = ConsDecl Ident Type
+
+data Expr
+  = App Expr Expr
+  | Var Ident
+  | Lam Ident Expr
+  | Let (Ident, Expr) Expr
+
+type Type = Expr
+
+data Pat
+  = PatVar Ident
+  

--- a/code/language-lambek/src/Language/Lambek/Ident.hs
+++ b/code/language-lambek/src/Language/Lambek/Ident.hs
@@ -1,0 +1,7 @@
+module Language.Lambek.Ident where
+
+import Prelude
+import Data.Text
+
+newtype Ident = Ident Text
+  deriving (Show)

--- a/code/language-lambek/src/Language/Lambek/Parse.hs
+++ b/code/language-lambek/src/Language/Lambek/Parse.hs
@@ -1,2 +1,55 @@
 module Language.Lambek.Parse where
-  
+
+import Language.Lambek.Defn
+import Language.Lambek.Ident
+
+import Prelude
+import Data.Functor
+import Data.Text
+import Text.Parsec
+import Text.Parsec.Language (haskell)
+import Text.Parsec.Token qualified
+
+pDefn :: Parsec String () Defn
+pDefn = do
+  ident <- pIdent
+  pats <- pPatterns
+  pKeyword "data" $> Data ident pats <*> pConsDecls
+
+pPatterns :: Parsec String () [Pat]
+pPatterns = many pPattern
+
+pPattern :: Parsec String () Pat
+pPattern = pure PatVar <*> pIdent
+
+pConsDecls :: Parsec String () [ConsDecl]
+pConsDecls =
+      (:) <$> pConsDecl <*> pConsDecls
+  <|> pure []
+
+pConsDecl :: Parsec String () ConsDecl
+pConsDecl = ConsDecl <$> pIdent <*> (pReservedOp "::" *> pExpr)
+
+pExpr :: Parsec String () Expr
+pExpr =
+      pAExpr
+  <|> App <$> pAExpr <*> pAExpr
+
+pAExpr :: Parsec String () Expr
+pAExpr = Var <$> pIdent <|> pParens pExpr
+
+data Token
+  = TIdent String
+  deriving (Eq, Ord, Show)
+
+pIdent :: Parsec String () Ident
+pIdent = Ident . pack <$> Text.Parsec.Token.identifier haskell
+
+pParens :: Parsec String () a -> Parsec String () a
+pParens = Text.Parsec.Token.parens haskell
+
+pKeyword :: String -> Parsec String () ()
+pKeyword = Text.Parsec.Token.reserved haskell
+
+pReservedOp :: String -> Parsec String () ()
+pReservedOp = Text.Parsec.Token.reservedOp haskell

--- a/code/language-lambek/src/Language/Lambek/Parse.hs
+++ b/code/language-lambek/src/Language/Lambek/Parse.hs
@@ -1,0 +1,2 @@
+module Language.Lambek.Parse where
+  

--- a/code/language-lambek/test
+++ b/code/language-lambek/test
@@ -1,0 +1,3 @@
+Example index data
+  A :: Example
+  B :: Example

--- a/default.nix
+++ b/default.nix
@@ -6,6 +6,7 @@
 
         packages = {
             hanjiru.source = ./code/hanjiru;
+            lambek.source = ./code/lambek;
             mhc.source = ./code/mhc;
             mhc-haskell.source = ./code/mhc-haskell;
         };

--- a/hie.yaml
+++ b/hie.yaml
@@ -4,6 +4,8 @@ cradle:
       component: "lib:hanjiru"
     - path: "code/hanjiru/apps/demo"
       component: "exe:demo"
+    - path: "code/language-lambek/src"
+      component: "lib:language-lambek"
     - path: "code/mhc/src"
       component: "lib:mhc"
     - path: "code/mhc-haskell/src"


### PR DESCRIPTION
Haskell, Idris, Agda, and other similarly-styled declarative languages use the following circumfix syntax declarations like `data`, `newtype`, `class`, `instance`, and `record`:
```hs
data Maybe a where
  Nothing :: Maybe a
  Just    :: a -> Maybe a

class Monad m where
  pure :: a -> m a

  (>>=) :: m a -> (a -> m b) -> m b

instance Monad m where
  pure = Just

  Nothing >>= k = Nothing
  Just a  >>= k = k a
```
It's fine for simple declarations. But more involved declarations are often cluttered, since nobody agrees on how they should be formatted.

I have come up with an alternative syntax for declarations:
```hs
Maybe a data
  Nothing :: Maybe a
  Just    :: a -> Maybe a

Monad m class
  pure :: a -> m a

  (>>=) :: m a -> (a -> m b) -> m b

Monad Maybe instance
  pure = Just

  Nothing >>= k = Nothing
  Just a  >>= k = k a
```
I still have to determine the exact BNF grammar for this syntax. `language-lambek` implements a proof-of-concept AST and parser for it.